### PR TITLE
77 add an option to make automatic scene switch time for each scene different

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,7 +70,16 @@ In addition to that, actions for entering/leaving a pause, the tuner and startin
 Inside the SceneSwitcher action, there are several global parameters that can/need to be changed:
 For scene switching:
 * menuScene - this should be the scene you want to load when you're in the menu or tuner
-* songScenes - a comma separated list of scenes you could switch to during a song play (at start, the first is used)
+* songScenes - a comma separated list of scenes you could switch to during a song play (at start, the first is used)  
+    * Song scenes can be switched automatically (see section scene switching)
+    * The configured global songSwitchPeriod can be overriden for each scene individually.
+    * It is possible to define a range, and have a randomized time each cycle  
+    * Example: Scene1,Scene2#5-10,Scene3,Scene4#7
+        * Scene1 would be active according to songSwitchPeriod
+        * Scene2 would be active between 5 and 10 seconds, randomized each time
+        * Scene3 would be active according to songSwitchPeriod
+        * Scene4 would be active for 7 seconds
+
 * pauseScene - the scene that will be loaded when pausing during a song
 
 For the sniffer connection:

--- a/SB_SceneSwitcher/CPHMock.cs
+++ b/SB_SceneSwitcher/CPHMock.cs
@@ -126,7 +126,7 @@ public class CPHmock : IInlineInvokeProxy
             _ => null
         };
 
-        if (value == null) Console.WriteLine($"Key {key} is not found in config.yml!");
+        if (value == null) Console.WriteLine($"{MockAppName}Key {key} is not found in config.yml!");
 
         return value;
     }
@@ -174,7 +174,7 @@ public class CPHmock : IInlineInvokeProxy
     {
         if (string.IsNullOrEmpty(config.logLevel))
         {
-            Console.WriteLine("logLevel not found! Will use default Level: " + DefaultLogLevel);
+            Console.WriteLine($"{MockAppName}logLevel not found! Will use default Level: {DefaultLogLevel}");
             config.logLevel = DefaultLogLevel.ToString();
         }
 
@@ -185,8 +185,7 @@ public class CPHmock : IInlineInvokeProxy
     {
         if (string.IsNullOrEmpty(config.logLevelSB))
         {
-            Console.WriteLine(MockAppName + "logLevelSB not found! Will use default Level: " +
-                              DefaultLogLevelSB);
+            Console.WriteLine($"{MockAppName}logLevelSB not found! Will use default Level: {DefaultLogLevelSB}");
             config.logLevelSB = DefaultLogLevelSB.ToString();
         }
 

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -695,6 +695,7 @@ public class CPHInline
                         // In this case we will log a warning, and ignore this data for the accumulation. It should fix itself next cycle
                         if ((additionalNotes < 0) || (additionalNotesHit < 0) || (additionalNotesMissed < 0))
                         {
+                            CPH.LogWarn(Constants.AppName + "Leaving pause lead to inconsistency in note data. they will be ignored for accumulation");
                             CPH.LogWarn(Constants.AppName +
                                         $"additionalNotes is negative! additionalNotes={additionalNotes} additionalNotesHit={additionalNotesHit} additionalNotesMissed={additionalNotesMissed} totalNotesThisStream={totalNotesThisStream} totalNotesHitThisStream={totalNotesHitThisStream} totalNotesMissedThisStream={totalNotesMissedThisStream}");
                         }
@@ -902,14 +903,6 @@ public class CPHInline
             {
                 CPH.LogDebug("currentScene IsSongScene");
                 CPH.LogVerbose($"songSceneAutoSwitchMode={songSceneAutoSwitchMode}");
-
-                if (songTimer < lastSongTimer)
-                {
-                    // When leaving pause, it is either a restart, in that case lastNoteData is from previous playthrough
-                    // or the timer roll back when resuming could lead to unexpected deltas.
-                    // In both cases we want to reset the lastNoteData to the current one to prevent underflows
-                    lastNoteData = currentResponse.MemoryReadout.NoteData;
-                }
 
                 if (switchScenes && ItsTimeToSwitchScene() && (songScenes.Length > 1))
                 {

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -322,7 +322,7 @@ public class CPHInline
         private Arrangement? currentArrangement = null!;
         private int currentSectionIndex;
         private int currentSongSceneIndex;
-        private int sceneSwitchPeriodInSeconds = 5;
+        private int defaultSceneSwitchPeriodInSeconds = 5;
 
         private Response currentResponse = null!;
         private NoteData lastNoteData = null!;
@@ -388,7 +388,7 @@ public class CPHInline
             songSceneAutoSwitchMode = GetGlobalVarSongSceneAutoSwitchMode();
             reactingToSections = GetGlobalVarAsBool(Constants.GlobalVarNameSectionActions);
 
-            sceneSwitchPeriodInSeconds = GetGlobalVarSceneSwitchPeriod();
+            defaultSceneSwitchPeriodInSeconds = GetGlobalVarSceneSwitchPeriod();
 
             itsBehavior = GetGlobalVarBehavior();
             blackListedScenes = GetGlobalVarBlackListedScenes();
@@ -887,7 +887,7 @@ public class CPHInline
 
         private bool ItsTimeToSwitchScene()
         {
-            return itsSceneInterActor.GetTimeSinceLastSceneChange() >= sceneSwitchPeriodInSeconds;
+            return itsSceneInterActor.GetTimeSinceLastSceneChange() >= defaultSceneSwitchPeriodInSeconds;
         }
 
         private void DoSequentialSceneSwitch()

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -311,9 +311,13 @@ public class CPHInline
         struct SongScene
         {
             public string Name;
+
             public enum Period
-            { FIXED
-            ,RANGE}
+            {
+                FIXED,
+                RANGE
+            }
+
             public Period period;
             public int minimumPeriod;
             public int currentSwitchPeriod;
@@ -403,7 +407,7 @@ public class CPHInline
             menuScene = GetGlobalVarAsString(Constants.GlobalVarNameMenuScene);
             string[] songScenesRaw = GetGlobalVarAsStringArray(Constants.GlobalVarNameMenuSongScenes);
             songScenes = new SongScene[songScenesRaw.Length];
-            for (int i = 0;i < songScenesRaw.Length; ++i)
+            for (int i = 0; i < songScenesRaw.Length; ++i)
             {
                 if (songScenesRaw[i].Contains("#"))
                 {
@@ -421,7 +425,6 @@ public class CPHInline
                         songScenes[i].period = SongScene.Period.FIXED;
                         songScenes[i].currentSwitchPeriod = int.Parse(temp[1]);
                     }
-
                 }
                 else
                 {
@@ -430,6 +433,7 @@ public class CPHInline
                     songScenes[i].currentSwitchPeriod = defaultSceneSwitchPeriodInSeconds;
                 }
             }
+
             songPausedScene = GetGlobalVarAsString(Constants.GlobalVarNamePauseScene);
 
             switchScenes = GetGlobalVarAsBool(Constants.GlobalVarNameSwitchScenes);
@@ -606,10 +610,10 @@ public class CPHInline
 
         private bool IsSongScene(string scene)
         {
-           foreach (SongScene s in songScenes)
+            foreach (SongScene s in songScenes)
                 if (s.Name.Equals(scene))
                     return true;
-           return false;
+            return false;
         }
 
         private void SaveSongMetaData()
@@ -695,7 +699,8 @@ public class CPHInline
                         // In this case we will log a warning, and ignore this data for the accumulation. It should fix itself next cycle
                         if ((additionalNotes < 0) || (additionalNotesHit < 0) || (additionalNotesMissed < 0))
                         {
-                            CPH.LogWarn(Constants.AppName + "Leaving pause lead to inconsistency in note data. they will be ignored for accumulation");
+                            CPH.LogWarn(Constants.AppName +
+                                        "Leaving pause lead to inconsistency in note data. they will be ignored for accumulation");
                             CPH.LogWarn(Constants.AppName +
                                         $"additionalNotes is negative! additionalNotes={additionalNotes} additionalNotesHit={additionalNotesHit} additionalNotesMissed={additionalNotesMissed} totalNotesThisStream={totalNotesThisStream} totalNotesHitThisStream={totalNotesHitThisStream} totalNotesMissedThisStream={totalNotesMissedThisStream}");
                         }
@@ -881,7 +886,7 @@ public class CPHInline
 
             var songTimer = currentResponse.MemoryReadout.SongTimer;
             CPH.LogVerbose(Constants.AppName + $"songTimer={songTimer} | lastSongTimer={lastSongTimer}");
-            
+
 
             if (IsSongScene(currentScene) == false)
             {
@@ -931,7 +936,8 @@ public class CPHInline
 
         private bool ItsTimeToSwitchScene()
         {
-            return itsSceneInterActor.GetTimeSinceLastSceneChange() >= songScenes[currentSongSceneIndex].currentSwitchPeriod;
+            return itsSceneInterActor.GetTimeSinceLastSceneChange() >=
+                   songScenes[currentSongSceneIndex].currentSwitchPeriod;
         }
 
         private void DoSequentialSceneSwitch()
@@ -943,7 +949,6 @@ public class CPHInline
 
             itsSceneInterActor.SwitchToScene(songScenes[currentSongSceneIndex].Name, switchScenes);
             songScenes[currentSongSceneIndex].RandomizePeriodIfNecessary();
-            
         }
 
         private void DoRandomSceneSwitch()
@@ -1079,7 +1084,7 @@ public class CPHInline
         itsFetcher = new ResponseFetcher(CPH, snifferIp, snifferPort);
         itsParser = new ResponseParser(CPH, itsSceneInteractor);
         itsParser.Init();
-        
+
 
         currentScene = "";
     }

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -221,7 +221,7 @@ public class CPHInline
         public double GetTimeSinceLastSceneChange()
         {
             var timeSinceLastSceneChange = DateTime.Now.Subtract(lastSceneChange).TotalSeconds;
-            CPH.LogVerbose($"timeSinceLastSceneChange={timeSinceLastSceneChange}");
+            CPH.LogVerbose($"{Constants.AppName}timeSinceLastSceneChange={timeSinceLastSceneChange}");
             return timeSinceLastSceneChange;
         }
     }
@@ -887,8 +887,7 @@ public class CPHInline
             var songTimer = currentResponse.MemoryReadout.SongTimer;
             CPH.LogVerbose(Constants.AppName + $"songTimer={songTimer} | lastSongTimer={lastSongTimer}");
 
-
-            if (IsSongScene(currentScene) == false)
+            if (!IsSongScene(currentScene))
             {
                 if (!songTimer.Equals(lastSongTimer))
                 {
@@ -906,8 +905,8 @@ public class CPHInline
             }
             else if (IsSongScene(currentScene))
             {
-                CPH.LogDebug("currentScene IsSongScene");
-                CPH.LogVerbose($"songSceneAutoSwitchMode={songSceneAutoSwitchMode}");
+                CPH.LogDebug($"{Constants.AppName}currentScene IsSongScene");
+                CPH.LogVerbose($"{Constants.AppName}songSceneAutoSwitchMode={songSceneAutoSwitchMode}");
 
                 if (switchScenes && ItsTimeToSwitchScene() && (songScenes.Length > 1))
                 {

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -407,15 +407,15 @@ public class CPHInline
             menuScene = GetGlobalVarAsString(Constants.GlobalVarNameMenuScene);
             string[] songScenesRaw = GetGlobalVarAsStringArray(Constants.GlobalVarNameMenuSongScenes);
             songScenes = new SongScene[songScenesRaw.Length];
-            for (int i = 0; i < songScenesRaw.Length; ++i)
+            for (var i = 0; i < songScenesRaw.Length; ++i)
             {
                 if (songScenesRaw[i].Contains("#"))
                 {
-                    string[] temp = songScenesRaw[i].Split("#");
+                    string[] temp = songScenesRaw[i].Split('#');
                     songScenes[i].Name = temp[0];
                     if (temp[1].Contains("-"))
                     {
-                        string[] temp2 = temp[1].Split("-");
+                        string[] temp2 = temp[1].Split('-');
                         songScenes[i].period = SongScene.Period.RANGE;
                         songScenes[i].minimumPeriod = int.Parse(temp2[0]);
                         songScenes[i].maximumPeriod = int.Parse(temp2[1]);

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -109,7 +109,7 @@ public class CPHInline
         InSong,
         InTuner
     }
-
+    
     enum SectionType
     {
         Default,
@@ -133,12 +133,12 @@ public class CPHInline
     {
         private const string MessageNoStreamAppConnectionAvailable =
             Constants.AppName +
-            "No stream app connection available! Please set and connect either to OBS or SLOBS under 'Stream Apps' in SB!";
+            "No stream app connection available! Please set and connect either to Obs or Slobs under 'Stream Apps' in SB!";
 
         enum StreamApp
         {
-            OBS,
-            SLOBS
+            Obs,
+            Slobs
         }
 
         private int cooldownPeriod;
@@ -157,13 +157,13 @@ public class CPHInline
         {
             if (CPH.ObsIsConnected())
             {
-                itsStreamApp = StreamApp.OBS;
-                CPH.LogDebug(Constants.AppName + $"Connected to {StreamApp.OBS}");
+                itsStreamApp = StreamApp.Obs;
+                CPH.LogDebug(Constants.AppName + $"Connected to {StreamApp.Obs}");
             }
             else if (CPH.SlobsIsConnected())
             {
-                itsStreamApp = StreamApp.SLOBS;
-                CPH.LogDebug(Constants.AppName + $"Connected to {StreamApp.SLOBS}");
+                itsStreamApp = StreamApp.Slobs;
+                CPH.LogDebug(Constants.AppName + $"Connected to {StreamApp.Slobs}");
             }
             else
             {
@@ -178,8 +178,8 @@ public class CPHInline
 
             return itsStreamApp switch
             {
-                StreamApp.OBS => CPH.ObsGetCurrentScene(),
-                StreamApp.SLOBS => CPH.SlobsGetCurrentScene(),
+                StreamApp.Obs => CPH.ObsGetCurrentScene(),
+                StreamApp.Slobs => CPH.SlobsGetCurrentScene(),
                 _ => ""
             };
         }
@@ -190,12 +190,12 @@ public class CPHInline
             {
                 switch (itsStreamApp)
                 {
-                    case StreamApp.OBS:
-                        CPH.LogInfo(Constants.AppName + $"Switching to OBS scene: {scene}");
+                    case StreamApp.Obs:
+                        CPH.LogInfo(Constants.AppName + $"Switching to Obs scene: {scene}");
                         CPH.ObsSetScene(scene);
                         break;
-                    case StreamApp.SLOBS:
-                        CPH.LogInfo(Constants.AppName + $"Switching to SLOBS scene: {scene}");
+                    case StreamApp.Slobs:
+                        CPH.LogInfo(Constants.AppName + $"Switching to Slobs scene: {scene}");
                         CPH.SlobsSetScene(scene);
                         break;
                     default:
@@ -314,8 +314,8 @@ public class CPHInline
 
             public enum Period
             {
-                FIXED,
-                RANGE
+                Fixed,
+                Range
             }
 
             public Period period;
@@ -325,7 +325,7 @@ public class CPHInline
 
             public void RandomizePeriodIfNecessary()
             {
-                if (period == SongScene.Period.RANGE)
+                if (period == Period.Range)
                 {
                     currentSwitchPeriod = new Random().Next(minimumPeriod, maximumPeriod + 1);
                 }
@@ -426,21 +426,21 @@ public class CPHInline
                     if (songSceneRaw[1].Contains("-"))
                     {
                         string[] minMax = songSceneRaw[1].Split('-');
-                        songScenes[i].period = SongScene.Period.RANGE;
+                        songScenes[i].period = SongScene.Period.Range;
                         songScenes[i].minimumPeriod = int.Parse(minMax[0]);
                         songScenes[i].maximumPeriod = int.Parse(minMax[1]);
                         songScenes[i].RandomizePeriodIfNecessary();
                     }
                     else
                     {
-                        songScenes[i].period = SongScene.Period.FIXED;
+                        songScenes[i].period = SongScene.Period.Fixed;
                         songScenes[i].currentSwitchPeriod = int.Parse(songSceneRaw[1]);
                     }
                 }
                 else
                 {
                     songScenes[i].Name = songScenesRaw[i];
-                    songScenes[i].period = SongScene.Period.FIXED;
+                    songScenes[i].period = SongScene.Period.Fixed;
                     songScenes[i].currentSwitchPeriod = defaultSceneSwitchPeriodInSeconds;
                 }
             }
@@ -927,7 +927,7 @@ public class CPHInline
                 }
                 else
                 {
-                    if (switchScenes && ItsTimeToSwitchScene() && songScenes.Length > 1)
+                    if (switchScenes && songScenes.Length > 1 && ItsTimeToSwitchScene())
                     {
                         switch (songSceneAutoSwitchMode)
                         {

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -308,6 +308,17 @@ public class CPHInline
 
     public class ResponseParser
     {
+        struct SongScene
+        {
+            public string Name;
+            public enum Period
+            { FIXED
+            ,RANGE}
+            public Period period;
+            public int minimumPeriod;
+            public int maximumPeriod;
+        }
+
         private GameStage currentGameStage;
         private GameStage lastGameStage;
         private SectionType currentSectionType;

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -213,8 +213,8 @@ public class CPHInline
             var isNotInCooldown = !(timeSinceLastSceneChange < cooldownPeriod);
             CPH.LogVerbose(
                 $"{Constants.AppName}isNotInCooldown={isNotInCooldown} - " +
-                $"timeSinceLastSceneChange={timeSinceLastSceneChange} " +
-                $"cooldownPeriod={cooldownPeriod} ");
+                           $"timeSinceLastSceneChange={timeSinceLastSceneChange} " +
+                           $"cooldownPeriod={cooldownPeriod} ");
             return isNotInCooldown;
         }
 
@@ -908,27 +908,30 @@ public class CPHInline
                 CPH.LogDebug($"{Constants.AppName}currentScene IsSongScene");
                 CPH.LogVerbose($"{Constants.AppName}songSceneAutoSwitchMode={songSceneAutoSwitchMode}");
 
-                if (switchScenes && ItsTimeToSwitchScene() && (songScenes.Length > 1))
-                {
-                    switch (songSceneAutoSwitchMode)
-                    {
-                        case SongSceneAutoSwitchMode.Sequential:
-                            DoSequentialSceneSwitch();
-                            break;
-                        case SongSceneAutoSwitchMode.Random:
-                            DoRandomSceneSwitch();
-                            break;
-                        case SongSceneAutoSwitchMode.Off:
-                        default:
-                            // Nothing to do
-                            break;
-                    }
-                }
-
                 if (IsInPause())
                 {
+                    CPH.LogDebug($"Is in Pause, switching to scene={songPausedScene}");
                     RunAction(Constants.ActionNameEnterPause);
                     itsSceneInterActor.SwitchToScene(songPausedScene, switchScenes);
+                }
+                else
+                {
+                    if (switchScenes && ItsTimeToSwitchScene() && songScenes.Length > 1)
+                    {
+                        switch (songSceneAutoSwitchMode)
+                        {
+                            case SongSceneAutoSwitchMode.Sequential:
+                                DoSequentialSceneSwitch();
+                                break;
+                            case SongSceneAutoSwitchMode.Random:
+                                DoRandomSceneSwitch();
+                                break;
+                            case SongSceneAutoSwitchMode.Off:
+                            default:
+                                // Nothing to do
+                                break;
+                        }
+                    }
                 }
             }
         }

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -319,7 +319,7 @@ public class CPHInline
             public int currentSwitchPeriod;
             public int maximumPeriod;
 
-            public void randomizePeriodIfNecessary()
+            public void RandomizePeriodIfNecessary()
             {
                 if (period == SongScene.Period.RANGE)
                 {
@@ -949,7 +949,7 @@ public class CPHInline
             }
 
             itsSceneInterActor.SwitchToScene(songScenes[currentSongSceneIndex].Name, switchScenes);
-            songScenes[currentSongSceneIndex].randomizePeriodIfNecessary();
+            songScenes[currentSongSceneIndex].RandomizePeriodIfNecessary();
             
         }
 
@@ -969,7 +969,7 @@ public class CPHInline
 
             currentSongSceneIndex = newSongSceneIndex;
             itsSceneInterActor.SwitchToScene(songScenes[currentSongSceneIndex].Name, switchScenes);
-            songScenes[currentSongSceneIndex].randomizePeriodIfNecessary();
+            songScenes[currentSongSceneIndex].RandomizePeriodIfNecessary();
         }
 
         private void RunAction(string actionName)

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -213,8 +213,8 @@ public class CPHInline
             var isNotInCooldown = !(timeSinceLastSceneChange < cooldownPeriod);
             CPH.LogVerbose(
                 $"{Constants.AppName}isNotInCooldown={isNotInCooldown} - " +
-                           $"timeSinceLastSceneChange={timeSinceLastSceneChange} " +
-                           $"cooldownPeriod={cooldownPeriod} ");
+                $"timeSinceLastSceneChange={timeSinceLastSceneChange} " +
+                $"cooldownPeriod={cooldownPeriod} ");
             return isNotInCooldown;
         }
 
@@ -320,8 +320,8 @@ public class CPHInline
 
             public Period period;
             public int minimumPeriod;
-            public int currentSwitchPeriod;
             public int maximumPeriod;
+            public int currentSwitchPeriod;
 
             public void RandomizePeriodIfNecessary()
             {
@@ -329,6 +329,16 @@ public class CPHInline
                 {
                     currentSwitchPeriod = new Random().Next(minimumPeriod, maximumPeriod + 1);
                 }
+            }
+
+            public override string ToString()
+            {
+                return
+                    $"{nameof(Name)}: {Name}, " +
+                    $"{nameof(period)}: {period}, " +
+                    $"{nameof(minimumPeriod)}: {minimumPeriod}, " +
+                    $"{nameof(maximumPeriod)}: {maximumPeriod}, " +
+                    $"{nameof(currentSwitchPeriod)}: {currentSwitchPeriod}";
             }
         }
 
@@ -411,19 +421,20 @@ public class CPHInline
             {
                 if (songScenesRaw[i].Contains("#"))
                 {
-                    string[] temp = songScenesRaw[i].Split('#');
-                    songScenes[i].Name = temp[0];
-                    if (temp[1].Contains("-"))
+                    string[] songSceneRaw = songScenesRaw[i].Split('#');
+                    songScenes[i].Name = songSceneRaw[0];
+                    if (songSceneRaw[1].Contains("-"))
                     {
-                        string[] temp2 = temp[1].Split('-');
+                        string[] minMax = songSceneRaw[1].Split('-');
                         songScenes[i].period = SongScene.Period.RANGE;
-                        songScenes[i].minimumPeriod = int.Parse(temp2[0]);
-                        songScenes[i].maximumPeriod = int.Parse(temp2[1]);
+                        songScenes[i].minimumPeriod = int.Parse(minMax[0]);
+                        songScenes[i].maximumPeriod = int.Parse(minMax[1]);
+                        songScenes[i].RandomizePeriodIfNecessary();
                     }
                     else
                     {
                         songScenes[i].period = SongScene.Period.FIXED;
-                        songScenes[i].currentSwitchPeriod = int.Parse(temp[1]);
+                        songScenes[i].currentSwitchPeriod = int.Parse(songSceneRaw[1]);
                     }
                 }
                 else
@@ -938,8 +949,10 @@ public class CPHInline
 
         private bool ItsTimeToSwitchScene()
         {
-            return itsSceneInterActor.GetTimeSinceLastSceneChange() >=
-                   songScenes[currentSongSceneIndex].currentSwitchPeriod;
+            var timeSinceLastSceneChange = itsSceneInterActor.GetTimeSinceLastSceneChange();
+            CPH.LogVerbose($"{Constants.AppName}songScene={songScenes[currentSongSceneIndex]}");
+            CPH.LogVerbose($"{Constants.AppName}timeSinceLastSceneChange={timeSinceLastSceneChange}");
+            return timeSinceLastSceneChange >= songScenes[currentSongSceneIndex].currentSwitchPeriod;
         }
 
         private void DoSequentialSceneSwitch()

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -113,7 +113,7 @@ public class CPHInline
         InSong,
         InTuner
     }
-    
+
     enum SectionType
     {
         Default,
@@ -953,7 +953,7 @@ public class CPHInline
                     RunAction(Constants.ActionNameEnterPause);
                     itsSceneInterActor.SwitchToScene(songPausedScene, switchScenes);
                 }
-                else if (switchScenes &&  (songScenes.Length > 1) && ItsTimeToSwitchScene())
+                else if (HasToSwitchScene())
                 {
                     switch (songSceneAutoSwitchMode)
                     {
@@ -967,9 +967,14 @@ public class CPHInline
                         default:
                             // Nothing to do
                             break;
-                    }                    
+                    }
                 }
             }
+        }
+
+        private bool HasToSwitchScene()
+        {
+            return switchScenes && HasMoreThan1Scenes() && ItsTimeToSwitchScene();
         }
 
         private bool ItsTimeToSwitchScene()
@@ -996,7 +1001,7 @@ public class CPHInline
             int newSongSceneIndex;
             do
             {
-                if (songScenes.Length == 1)
+                if (HasOnly1Scene())
                 {
                     newSongSceneIndex = 0;
                     break;
@@ -1008,6 +1013,16 @@ public class CPHInline
             currentSongSceneIndex = newSongSceneIndex;
             itsSceneInterActor.SwitchToScene(songScenes[currentSongSceneIndex].Name, switchScenes);
             songScenes[currentSongSceneIndex].RandomizePeriodIfNecessary();
+        }
+
+        private bool HasOnly1Scene()
+        {
+            return songScenes.Length == 1;
+        }
+
+        private bool HasMoreThan1Scenes()
+        {
+            return songScenes.Length > 1;
         }
 
         private void RunAction(string actionName)


### PR DESCRIPTION
Implemented with your suggested syntax, e.g.

Scene1, Scene2#7, Scene3#1-25000

Scene1 will fall back to globally configured period:
Scene 2 will use 7 seconds instead
Scene 3 will randomize between 1 and 25000